### PR TITLE
Add mozilla-l10n organization to allow list

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,7 @@
   "content_scripts": [
     {
       "js": ["content.js"],
-      "matches": ["https://github.com/mozilla-firefox/*"],
+      "matches": ["https://github.com/mozilla-firefox/*", "https://github.com/mozilla-l10n/*"],
       "run_at": "document_idle",
       "world": "MAIN"
     }


### PR DESCRIPTION
The extension does not work on the mozilla-l10n organization repositories, noticed today while making PR's for dictionary updates there.