### PR TITLE
Switch to ISOLATED executionContext

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,8 +14,7 @@
     {
       "js": ["content.js"],
       "matches": ["https://github.com/mozilla-firefox/*", "https://github.com/mozilla-l10n/*"],
-      "run_at": "document_idle",
-      "world": "MAIN"
+      "run_at": "document_idle"
     }
   ]
 }


### PR DESCRIPTION
Unless MAIN is strictly necessary, using this context currently prevents debugging with devtools easily (see https://bugzilla.mozilla.org/show_bug.cgi?id=1910624)

I tested the extension with the default (ISOLATED) context, and it seems to work fine.