### PR TITLE
Fix multiline commit messages being truncated by adding dotAll flag to regex

### DIFF
--- a/content.js
+++ b/content.js
@@ -13,7 +13,7 @@ function replaceBug(element) {
   }
 
   let text = element.textContent;
-  let match = /(.*)?([Bb]ug\s+#?(\d{3,}))(.*)?/.exec(text);
+  let match = /(.*)?([Bb]ug\s+#?(\d{3,}))(.*)?/s.exec(text);
   if (match) {
     let span = document.createElement("span");
 


### PR DESCRIPTION
The `s` flag (dotAll) makes `.` match newlines, so `match[4]` now captures the full remainder of the text node including any line breaks.

I've verified locally that this now shows multiline commit messages as expected. Fixes #4 